### PR TITLE
Restrict summary tables to self-play games and Asymmetric-only Both Beat Baseline

### DIFF
--- a/analysis/format_results.py
+++ b/analysis/format_results.py
@@ -55,7 +55,10 @@ def format_data(in_df, p4p=True):
     
     models = df["Model Pair"].str.partition("-")
     same_model = models[0] == models[2]
-    df["Model"] = np.where(same_model, models[0], df["Model Pair"])
+    # only analyze self-play games; cross-play pairs (e.g. FOUR_1-HAIKU_4_5) are handled separately
+    df = df[same_model]
+    models = models[same_model]
+    df["Model"] = models[0]
     model_map = {
         "FOUR_1": "GPT-4.1",
         "HAIKU_4_5": "Haiku-4.5",

--- a/analysis/format_results.py
+++ b/analysis/format_results.py
@@ -31,9 +31,9 @@ MODEL_ORDER = ["GPT-4.1", "Haiku-4.5", "LLaMA Maverick", "LLaMA Scout", "Qwen-3-
 BUCKET_ORDER = ["Independent", "Mutually Dependent", "Asymmetric"]
 CONTRACT_ORDER = ['No Contract', 'Prog-Points',   'NL-Trading', 'Prog-Trading']
 
-def format_data(in_df, p4p=True):
+def format_data(in_df, p4p=True, self_play_only=True):
     df = in_df.copy()
-    df = df[df['Pay4Partner'] == p4p] 
+    df = df[df['Pay4Partner'] == p4p]
 
     config_map = {
         "ctx1_fog00_p4pfalse_contract_contract_for_finishing_selfish11": "Finishing Contract",
@@ -55,10 +55,12 @@ def format_data(in_df, p4p=True):
     
     models = df["Model Pair"].str.partition("-")
     same_model = models[0] == models[2]
-    # only analyze self-play games; cross-play pairs (e.g. FOUR_1-HAIKU_4_5) are handled separately
-    df = df[same_model]
-    models = models[same_model]
-    df["Model"] = models[0]
+    if self_play_only:
+        # drop cross-play pairs (e.g. FOUR_1-HAIKU_4_5)
+        df = df[same_model]
+        models = models[same_model]
+        same_model = same_model[same_model]
+    df["Model"] = np.where(same_model, models[0], df["Model Pair"])
     model_map = {
         "FOUR_1": "GPT-4.1",
         "HAIKU_4_5": "Haiku-4.5",

--- a/analysis/print_summary_tables.py
+++ b/analysis/print_summary_tables.py
@@ -218,7 +218,8 @@ if __name__ == "__main__":
     for contract in CONTRACT_ORDER:
         print(f"\n\n=== Contract: {contract} ===")
         print_model_metric_summaries(
-            df=df_p4p[df_p4p["Contract Type"] == contract],
+            df=df_p4p,
+            contract_types=[contract],
             metrics=metrics,
             model_col="Model",
             output_latex=True,
@@ -240,7 +241,7 @@ if __name__ == "__main__":
                 "Defection Rate": 3,
                 "contract_accepted": 3,
             },
-            asymmetric_only_metrics=["Defection Rate", "contract_accepted"],
+            asymmetric_only_metrics=["Both Beat Baseline", "Defection Rate", "contract_accepted"],
             show_overall_mean=True,
             ci=0.95,
             appendix=False,
@@ -250,7 +251,8 @@ if __name__ == "__main__":
     for contract in CONTRACT_ORDER:
         print(f"\n\n=== Contract: {contract} (Regular Trading) ===")
         print_model_metric_summaries(
-            df=df_reg_trading[df_reg_trading["Contract Type"] == contract],
+            df=df_reg_trading,
+            contract_types=[contract],
             metrics=metrics,
             model_col="Model",
             output_latex=True,
@@ -272,7 +274,7 @@ if __name__ == "__main__":
                 "Defection Rate": 3,
                 "contract_accepted": 3,
             },
-            asymmetric_only_metrics=["Defection Rate", "contract_accepted"],
+            asymmetric_only_metrics=["Both Beat Baseline", "Defection Rate", "contract_accepted"],
             show_overall_mean=True,
             ci=0.95,
             appendix=False,


### PR DESCRIPTION
## What changed

- **`analysis/format_results.py`**: `format_data` gains a `self_play_only` flag (default `True`) that drops cross-play rows (e.g. `FOUR_1-HAIKU_4_5`). The current `results/all_runs_latest.csv` happens to contain only the 6 self-play pairs, but `analyze_experiments.py` scans all of `public_logs/reduced_config_runs` with no filter — and that tree contains cross-play run dirs (~80 runs each) — so regenerating the CSV would have silently pulled them into every downstream analysis. Pass `self_play_only=False` to keep cross-play rows (original behavior: `Model` is set to the full pair string).
- **`analysis/print_summary_tables.py`**: `Both Beat Baseline` is now in `asymmetric_only_metrics`, so it's computed on Asymmetric boards only (like Defection Rate / Contract Accepted). Previously it was averaged over all boards, which deflates/muddles the metric since Independent boards can never have both players beat baseline. For p4p=False No Contract this changes the overall mean from 0.32 ± 0.04 to 0.20 ± 0.05 (per-model n drops to ~80, so CIs widen accordingly).
- **Crash fix**: the `__main__` loops now pass `contract_types=[contract]` to `print_model_metric_summaries` instead of pre-filtering the dataframe. Previously the LaTeX caption line indexed `contract_types[0]` while `contract_types` was `None`, so running the script directly crashed after the first table body.

## Notes for review

- Verified the current CSV contains exactly the 6 self-play pairs, 320 rows per pair per p4p condition, so tables produced before this change were not contaminated by cross-play data — the new filter is protection against future CSV regeneration.
- Downstream scripts importing `format_data` (heatmap, master_graph, etc.) get the self-play-only default; any cross-play analysis can opt out with `self_play_only=False`. `generate_cross_model_table.py` reads the log dirs directly and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)